### PR TITLE
[docs]Fix the typesetting of  `compiler/README.md`

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -2,17 +2,17 @@
 
 megcc depend on llvm-project and megbrain, now llvm-project and megbrain are integrated by submodule, and static linked into megcc
 - update third-party submodule
-
+```
     $ cd megcc
     $ ./third_party/prepare.sh
-
+```
 - build megcc
-
+```
     $ cd megcc/compiler
     $ mkdir build
     $ cmake .. -G Ninja
     $ ninja
-
+```
 after build the compiler tools is stored in build/tools/...
 
 ### kernel test


### PR DESCRIPTION
When I first read the doc, I get the typesetting like this:
---
![image](https://user-images.githubusercontent.com/77330637/198589744-79409ffe-1e46-4903-8c5e-0a06403fb4d0.png)
---
So it will be better to fix it. :)